### PR TITLE
Use setup-cfg-fmt to provide a more standardized setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,31 +5,26 @@
 [metadata]
 name = cython-iscsi
 description = Cython-based wrapper for libiscsi.
-url = https://github.com/python-scsi/cython-iscsi
-license_files =
-   AUTHORS
-   LICENSES/*
-long_description = file:README.md
+long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/python-scsi/cython-iscsi
 maintainer = Markus Rosjat
 maintainer_email = markus.rosjat@gmail.com
 license = LGPL-2.1+
+license_files =
+    AUTHORS
+    LICENSES/*
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
+    Programming Language :: Python
+    Programming Language :: Python :: 3
 keywords =
     scsi
     iscsi
-classifiers =
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Development Status :: 4 - Beta
-    License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
 
 [options]
 packages = find:
-
-[options.package_data]
-* =
-    *.pyx
-    *.pxd
 
 [options.extras_require]
 dev =
@@ -41,6 +36,11 @@ dev =
     setuptools>=42
     setuptools_scm[toml]>=3.4
     wheel
+
+[options.package_data]
+* =
+    *.pyx
+    *.pxd
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This maintains the E501 ignore reason _and_ the SPDX headers.