### PR TITLE
Add raw_sense property to Task

### DIFF
--- a/src/iscsi.pyx
+++ b/src/iscsi.pyx
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from libc.stdlib cimport calloc
+from cpython.bytes cimport PyBytes_FromStringAndSize
 
 
 cdef extern from "iscsi/scsi-lowlevel.h":
@@ -13,8 +14,12 @@ cdef extern from "iscsi/scsi-lowlevel.h":
         SCSI_XFER_READ
         SCSI_XFER_WRITE
 
+    cdef struct scsi_data:
+        int size
+        char *data
+
     cdef struct scsi_task:
-        pass
+        scsi_data datain
 
     cdef struct scsi_sense:
         pass
@@ -89,6 +94,9 @@ cdef class Task:
     def status(self):
         return scsi_task_get_status(self._task, NULL)
 
+    @property
+    def raw_sense(self):
+        return PyBytes_FromStringAndSize(&self._task.datain.data[2], self._task.datain.size-2)
 
 cdef class Context:
     cdef iscsi_context *_ctx


### PR DESCRIPTION
Add the ability to retrieve the **raw** sense data from a Task, following execution of a command.

This is copied to _task->datain_ during the handling of `SCSI_STATUS_CHECK_CONDITION` by `iscsi_process_scsi_reply`.

[This PR eliminates the need for an earlier [PR](https://github.com/python-scsi/cython-iscsi/pull/7) that fetched the (partially) **processed** sense data.  Using the raw data also has the advantage that it has been available in _libiscsi_ from version 1.1.0 onwards.]

