### PR TITLE
Add support for iSCSI discovery

### DIFF
--- a/src/iscsi.pyx
+++ b/src/iscsi.pyx
@@ -4,8 +4,8 @@
 #
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from libc.stdlib cimport calloc
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from libc.stdlib cimport calloc
 
 
 cdef extern from "iscsi/scsi-lowlevel.h":
@@ -62,11 +62,22 @@ cdef extern from "iscsi/iscsi.h":
     cdef struct iscsi_data:
         pass
 
+    cdef struct iscsi_target_portal:
+        iscsi_target_portal *next
+        char *portal
+
+    cdef struct iscsi_discovery_address:
+        iscsi_discovery_address *next
+        char *target_name
+        iscsi_target_portal *portals
+
     cdef iscsi_context *iscsi_create_context(const char *initiator_name)
     cdef iscsi_url *iscsi_parse_full_url(iscsi_context *iscsi, const char* url)
     cdef int iscsi_set_targetname(iscsi_context *iscsi, const char *targetname)
     cdef int iscsi_set_session_type(iscsi_context *iscsi, iscsi_session_type session_type)
     cdef int iscsi_set_header_digest(iscsi_context *iscsi, iscsi_header_digest header_digest)
+    cdef int iscsi_set_initiator_username_pwd(iscsi_context *iscsi, const char *user, const char *passwd)
+    cdef int iscsi_set_target_username_pwd(iscsi_context *iscsi, const char *user, const char *passwd)
     cdef int iscsi_full_connect_sync(iscsi_context *iscsi, const char *portal, int lun)
     cdef int iscsi_disconnect(iscsi_context *iscsi)
 
@@ -77,6 +88,8 @@ cdef extern from "iscsi/iscsi.h":
         iscsi_context *iscsi, int lun, scsi_task *task, iscsi_data *data)
     cdef int scsi_task_get_status(scsi_task *task, scsi_sense *sense)
 
+    cdef iscsi_discovery_address *iscsi_discovery_sync(iscsi_context *iscsi)
+    cdef void iscsi_free_discovery_data(iscsi_context *iscsi, iscsi_discovery_address *da)
 
 cdef class Task:
     cdef scsi_task *_task
@@ -118,6 +131,14 @@ cdef class Context:
         if iscsi_set_header_digest(self._ctx, header_digest) < 0:
             raise ValueError("Invalid header digest: %s" % header_digest)
 
+    def set_initiator_username_pwd(self, str user, str passwd):
+        if iscsi_set_initiator_username_pwd(self._ctx, user.encode('utf-8'), passwd.encode('utf-8')) < 0:
+            raise ValueError("Invalid initiator user/pass: %s" % user)
+
+    def set_target_username_pwd(self, str user, str passwd):
+        if iscsi_set_target_username_pwd(self._ctx, user.encode('utf-8'), passwd.encode('utf-8')) < 0:
+            raise ValueError("Invalid target user/pass: %s" % user)
+
     def connect(self, str portal, int lun):
         if iscsi_full_connect_sync(self._ctx, portal.encode('utf-8'), lun) < 0:
             raise RuntimeError("Unable to connect to %s" % portal)
@@ -140,6 +161,20 @@ cdef class Context:
 
         iscsi_scsi_command_sync(self._ctx, lun, task._task, NULL)
 
+    def discover(self):
+        _da = iscsi_discovery_sync(self._ctx)
+        result = {}
+        da = _da
+        while da:
+            portals = []
+            dp = da.portals
+            while dp:
+                portals.append(dp.portal.decode('utf-8'))
+                dp = dp.next
+            result[da.target_name.decode('utf-8')] = portals
+            da = da.next
+        iscsi_free_discovery_data(self._ctx, _da)
+        return result
 
 cdef class URL:
     cdef iscsi_url *_url


### PR DESCRIPTION
Add support for iSCSI discovery

This uses `iscsi_discovery_sync` which was added to `libiscsi` in version [1.18.0](https://github.com/sahlberg/libiscsi/blob/master/packaging/RPM/libiscsi.spec.in#L125) (Oct 9 2016) in commit https://github.com/sahlberg/libiscsi/commit/d3ef192021fa8c9e523ce3c619ee0dc77d0f614b

Have also added CHAP and Mutual CHAP support by plumbing `iscsi_set_initiator_username_pwd` and `iscsi_set_target_username_pwd`.  The former is available since version 1.1.0 (commit https://github.com/sahlberg/libiscsi/commit/40abe849b01eb552d18dc01b4a4b26e4d84c5864), whereas the latter was added in version 1.14.0 (commit https://github.com/sahlberg/libiscsi/commit/b1d0ac45f16a7d6804d1d582ba5673b434d980e0)

Example usage:
```
import iscsi
import pprint
ctx = iscsi.Context('iqn.1993-08.org.debian:01:1da68ca3c4ec')
ctx.set_session_type(iscsi.ISCSI_SESSION_DISCOVERY)
ctx.set_header_digest(iscsi.ISCSI_HEADER_DIGEST_NONE)
# ctx.set_initiator_username_pwd("user1", "12charsecret")
# ctx.set_target_username_pwd("user2", "13charsecret1")
ctx.connect('192.168.100.101', -1)
result = ctx.discover()
ctx.disconnect()
pprint.pprint(result)

```