### PR TITLE
Fix tests in preparation for behavior change in modern Cython

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/tests/iscsi_test.py
+++ b/tests/iscsi_test.py
@@ -17,26 +17,32 @@ class ContextTest(unittest.TestCase):
     def test_set_context_params(self):
         context = iscsi.Context("foobar")
         context.set_targetname("my-target")
-        context.set_header_digest(iscsi.ISCSI_HEADER_DIGEST_NONE)
+        context.set_header_digest(iscsi.iscsi_header_digest.ISCSI_HEADER_DIGEST_NONE)
 
     def test_command(self):
         context = iscsi.Context("foobar")
-        task = iscsi.Task(b"\x12\x00\x00\x00\x60\x00", iscsi.SCSI_XFER_READ, 96)
+        task = iscsi.Task(
+            b"\x12\x00\x00\x00\x60\x00", iscsi.scsi_xfer_dir.SCSI_XFER_READ, 96
+        )
         data_in = bytearray(96)
         context.command(0, task, None, data_in)
 
 
 class TaskTest(unittest.TestCase):
     def test_basic(self):
-        task = iscsi.Task(b"\x12\x00\x00\x00\x60\x00", iscsi.SCSI_XFER_READ, 96)
+        task = iscsi.Task(
+            b"\x12\x00\x00\x00\x60\x00", iscsi.scsi_xfer_dir.SCSI_XFER_READ, 96
+        )
         self.assertIsNotNone(task)
 
     def test_bytearray(self):
         task = iscsi.Task(
-            bytearray(b"\x12\x00\x00\x00\x60\x00"), iscsi.SCSI_XFER_READ, 96
+            bytearray(b"\x12\x00\x00\x00\x60\x00"),
+            iscsi.scsi_xfer_dir.SCSI_XFER_READ,
+            96,
         )
         self.assertIsNotNone(task)
 
     def test_empty_cdb(self):
         with self.assertRaises(ValueError):
-            iscsi.Task(None, iscsi.SCSI_XFER_READ, 96)
+            iscsi.Task(None, iscsi.scsi_xfer_dir.SCSI_XFER_READ, 96)


### PR DESCRIPTION
Modern `cython` changes how `cpdef enum`s are exposed.  Update the tests so that they will work with **both** old and new cython.

Given
```
    cpdef enum iscsi_session_type:
        ISCSI_SESSION_DISCOVERY
        ISCSI_SESSION_NORMAL
```
We used to be able to _**either**_ use `iscsi.ISCSI_SESSION_NORMAL` or `iscsi.iscsi_session_type.ISCSI_SESSION_NORMAL`.  With modern cython, only the latter works.

From https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#structs-unions-enums

> Up to Cython version 3.0.x, this used to copy all item names into the global module namespace, so that they were available both as attributes of the Python enum type (CheseState above) and as global constants. This was changed in Cython 3.1 to distinguish between anonymous cpdef enums, which only create global Python constants for their items, and named cpdef enums, where the items live only in the namespace of the enum type and do not create global Python constants.

Verified the breakage and fix **in a venv** on Debian Trixie nightly, and on Bookworm.

The https://pypi.org/project/Cython/ shows
- 3.1.0 (2025-05-08)
