### PR TITLE
Add Context.lun_reset() to expose iscsi_task_mgmt_lun_reset_sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,14 +16,14 @@ repos:
         additional_dependencies:
           - toml
 -   repo: https://github.com/python/black
-    rev: 23.3.0
+    rev: 24.4.2
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     - id: flake8
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v4.0.3
     hooks:
     - id: reuse

--- a/src/iscsi.pyx
+++ b/src/iscsi.pyx
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 from cpython.bytes cimport PyBytes_FromStringAndSize
+from libc.stdint cimport uint32_t
 from libc.stdlib cimport calloc
 
 
@@ -91,6 +92,8 @@ cdef extern from "iscsi/iscsi.h":
     cdef iscsi_discovery_address *iscsi_discovery_sync(iscsi_context *iscsi)
     cdef void iscsi_free_discovery_data(iscsi_context *iscsi, iscsi_discovery_address *da)
 
+    cdef int iscsi_task_mgmt_lun_reset_sync(iscsi_context *iscsi, uint32_t lun)
+
 cdef class Task:
     cdef scsi_task *_task
 
@@ -146,6 +149,10 @@ cdef class Context:
     def disconnect(self):
         if iscsi_disconnect(self._ctx) < 0:
             raise RuntimeError("Disconnection error.")
+
+    def lun_reset(self, int lun):
+        if iscsi_task_mgmt_lun_reset_sync(self._ctx, lun) < 0:
+            raise RuntimeError("LUN RESET failed for lun %d" % lun)
 
     def command(self, int lun, Task task, bytearray data_out, bytearray data_in):
         # Get the data in/out bytearrays here so that Python can't change them.


### PR DESCRIPTION
Expose `iscsi_task_mgmt_lun_reset_sync` as `Context.lun_reset(lun)`.

`iscsi_task_mgmt_lun_reset_sync` has been part of libiscsi for more than a decade. The new method follows the same error-handling convention as the rest of the `Context` API: returns `None` on success, raises `RuntimeError` on failure.
