### PR TITLE
chore: update pre-commit hooks and GitHub Actions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,13 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Install APT dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,26 +4,26 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+-   repo: https://github.com/PyCQA/isort
+    rev: 8.0.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
 -   repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 24.4.0
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+    rev: 7.3.0
     hooks:
     - id: flake8
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.0.0
+    rev: v4.0.3
     hooks:
     - id: reuse


### PR DESCRIPTION
- Updated pre-commit hooks to their latest versions:
  - pre-commit-hooks: v6.0.0
  - isort: 8.0.1
  - black: 24.4.0
  - flake8: 7.3.0
  - reuse-tool: v4.0.3
- Updated GitHub Actions workflows to use the latest versions of actions:
  - actions/checkout: v4
  - actions/setup-python: v5